### PR TITLE
CustomReponse widget

### DIFF
--- a/lib/src/core/server_main.dart
+++ b/lib/src/core/server_main.dart
@@ -160,6 +160,11 @@ class Json extends Widget<dynamic> {
   Json(dynamic data) : super(data);
 }
 
+class CustomResponse extends Widget<Function> {
+  Future<dynamic> Function() builder;
+  CustomResponse(this.builder) : super(builder);
+}
+
 class Socket extends Widget<void> {
   Socket(this.context, {@required this.builder}) : super(null);
   final Context context;

--- a/lib/src/routes/route.dart
+++ b/lib/src/routes/route.dart
@@ -133,6 +133,8 @@ class Route {
         request.response.sendJson(widget.data);
       } else if (widget is Html) {
         request.response.sendFile(widget.data);
+      } else if (widget is CustomResponse) {
+        widget.builder?.call();
       } else {
         request.response.send(widget.data);
       }


### PR DESCRIPTION
In some cases it is necessary to return a status other than the StatusCode 200.
Example:
findUserById () and the user is not found, so we must return StatusCode 404.

#### real example
```dart
class CitysFromState extends GetView {
  Repository repository = Repository();
  @override
  build(Context context) {
    List<String> cidades = repository.citysFromState(context.param('id'));
    if (cidades.isEmpty) {
      return CustomResponse(
          () => context.response.status(404).send('Estado não encontrado'));
    } else {
      return Json(cidades);
    }
  }
}

```

obs: Desculpa pelo o péssimo inglês.