### PR TITLE
fix widget tree

### DIFF
--- a/lib/src/routes/route.dart
+++ b/lib/src/routes/route.dart
@@ -132,23 +132,26 @@ class Route {
       } else {
         widget = prepareWidget;
       }
-      print(widget.runtimeType.toString());
-      if (widget is Text) {
-        request.response.send(widget.data);
-      } else if (widget is Json) {
-        request.response.sendJson(widget.data);
-      } else if (widget is Html) {
-        request.response.sendFile(widget.data);
-      } else if (widget is HtmlText) {
-        request.response.sendHtmlText(widget.data);
-      } else if (widget is WidgetBuilder) {
-        widget.builder?.call(BuildContext(request, socketStream));
-      } else if (widget is GetWidget) {
-        final wid = await widget.build(BuildContext(request, socketStream));
-        request.response.send(wid.data);
-      } else {
-        request.response.send(widget.data);
-      }
+      _sendResponse(widget, request);
+    }
+  }
+
+  void _sendResponse(widget, request) async {
+    if (widget is Text) {
+      request.response.send(widget.data);
+    } else if (widget is Json) {
+      request.response.sendJson(widget.data);
+    } else if (widget is Html) {
+      request.response.sendFile(widget.data);
+    } else if (widget is HtmlText) {
+      request.response.sendHtmlText(widget.data);
+    } else if (widget is WidgetBuilder) {
+      widget.builder?.call(BuildContext(request, socketStream));
+    } else if (widget is GetWidget) {
+      final wid = await widget.build(BuildContext(request, socketStream));
+      _sendResponse(wid, request);
+    } else {
+      request.response.send(widget.data);
     }
   }
 

--- a/lib/src/widgets/pageable.dart
+++ b/lib/src/widgets/pageable.dart
@@ -62,7 +62,7 @@ class Pageable extends GetWidget {
         totalElements: list.length,
         totalPages: totalPages);
 
-    return Json(pageable.toJson());
+    return Json(pageable);
   }
 }
 
@@ -89,7 +89,7 @@ class _Pageable {
           content is List<DateTime>) {
         data['content'] = content;
       } else {
-        data['content'] = content.map((v) => jsonEncode(v)).toList();
+        data['content'] = content.map((v) => v.toJson()).toList();
       }
     }
     data['size'] = size;


### PR DESCRIPTION
- The `_sendResponse()` method was created, which processes the widget tree, regardless of the size.
- toJson,  it is necessary.
the current way causes error: 
 `data['content'] = content.map((v) => jsonEncode(v)).toList();`
![Captura de Tela 2020-09-22 às 21 17 51](https://user-images.githubusercontent.com/54460776/93950933-4f9f3680-fd1b-11ea-8a74-e2df3b136be0.png)
with `tojson()` works well
![Captura de Tela 2020-09-22 às 21 35 19](https://user-images.githubusercontent.com/54460776/93951003-87a67980-fd1b-11ea-8e5a-f5299f7fc49d.png)

obs: does not need a tojson before sending an object, just placing an object is enough