### PR TITLE
Improve JWT Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,12 @@ void main() {
 Second, retrieve your token:
 ```dart
 final claimSet = JwtClaim(
-  maxAge: const Duration(minutes: 5),
   expiry: DateTime.now().add(Duration(days: 3)),
   issuer: 'get is awesome',
   issuedAt: DateTime.now(),
 );
 
-var token = TokenUtil.generateToken(claim: claimSet, jwtKey: 'your key here');
+var token = TokenUtil.generateToken(claim: claimSet);
 ```
 and finally just flag your routes that need the token to work:
 ```dart

--- a/example/lib/pages/auth/controller/view_controller.dart
+++ b/example/lib/pages/auth/controller/view_controller.dart
@@ -10,6 +10,6 @@ class AuthController extends GetxController {
       issuedAt: DateTime.now(),
     );
 
-    return TokenUtil.generateToken(claim: claimSet, jwtKey: 'S3CR3T');
+    return TokenUtil.generateToken(claim: claimSet);
   }
 }

--- a/lib/src/core/server_main.dart
+++ b/lib/src/core/server_main.dart
@@ -75,6 +75,8 @@ class GetServer {
 
   Future<GetServer> start() {
     if (getPages != null) {
+      if (jwtKey != null) TokenUtil.saveJwtKey(jwtKey);
+
       getPages.forEach((route) {
         _routes.add(
           Route(
@@ -84,7 +86,6 @@ class GetServer {
             binding: route.binding,
             keys: route.keys,
             needAuth: route.needAuth,
-            jwtKey: jwtKey,
           ),
         );
       });

--- a/lib/src/core/utils/token_util.dart
+++ b/lib/src/core/utils/token_util.dart
@@ -1,16 +1,24 @@
+import 'package:get_server/get_server.dart';
 import 'package:jaguar_jwt/jaguar_jwt.dart';
 import 'package:meta/meta.dart';
 
 abstract class TokenUtil {
-  static String generateToken({
-    @required JwtClaim claim,
-    @required String jwtKey,
-  }) {
+  static String generateToken({@required JwtClaim claim}) {
     try {
-      var token = issueJwtHS256(claim, jwtKey);
+      var key = getJwtKey();
+      var token = issueJwtHS256(claim, key);
       return token;
     } catch (err) {
       rethrow;
     }
+  }
+
+  static String getJwtKey() {
+    var key = Get.find<String>(tag: 'jwtKey');
+    return key;
+  }
+
+  static void saveJwtKey(String jwtKey) {
+    Get.put(jwtKey, tag: 'jwtKey');
   }
 }

--- a/lib/src/core/utils/token_util.dart
+++ b/lib/src/core/utils/token_util.dart
@@ -13,6 +13,15 @@ abstract class TokenUtil {
     }
   }
 
+  static JwtClaim getClaims(String token) {
+    try {
+      var key = getJwtKey();
+      return verifyJwtHS256Signature(token, key);
+    } catch (err) {
+      rethrow;
+    }
+  }
+
   static String getJwtKey() {
     var key = Get.find<String>(tag: 'jwtKey');
     return key;

--- a/lib/src/routes/route.dart
+++ b/lib/src/routes/route.dart
@@ -79,9 +79,7 @@ class BuildContext {
 
 String enumValueToString(Object o) => o.toString().split('.').last;
 
-extension Soc on WebSocket{
-
-}
+extension Soc on WebSocket {}
 
 class Route {
   final _socketController = StreamController<HttpRequest>();
@@ -153,7 +151,10 @@ class Route {
           _sendResponse(widget, request);
         } else {
           request.response.status(401);
-          _sendResponse(Text('401 UNAUTHORIZED\n$message'), request);
+          _sendResponse(
+            Json({'success': false, 'data': null, 'error': message}),
+            request,
+          );
         }
       } else {
         _sendResponse(widget, request);

--- a/lib/src/routes/route.dart
+++ b/lib/src/routes/route.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:get_instance/get_instance.dart';
+import 'package:get_server/get_server.dart';
 import 'package:get_server/src/core/server_main.dart';
 import 'package:jaguar_jwt/jaguar_jwt.dart';
 
@@ -89,7 +90,6 @@ class Route {
   final Map _path;
   final Bindings binding;
   final bool _needAuth;
-  final String _jwtKey;
   FutureOr<Widget> Function(BuildContext context) _call;
 
   Route(
@@ -103,7 +103,6 @@ class Route {
     Map<String, List<WebSocket>> rooms,
   })  : _method = method,
         _needAuth = needAuth,
-        _jwtKey = jwtKey,
         _path = _normalize(path, keys: keys) {
     if (_method == Method.ws) {
       socketStream =
@@ -146,7 +145,7 @@ class Route {
       }
 
       if (_needAuth) {
-        var message = _authHandler(request, _jwtKey);
+        var message = _authHandler(request);
         if (message == null) {
           _sendResponse(widget, request);
         } else {
@@ -236,7 +235,7 @@ class Route {
     return params;
   }
 
-  String _authHandler(ContextRequest req, String jwtKey) {
+  String _authHandler(ContextRequest req) {
     dynamic token = req.header('Authorization');
     try {
       if (token != null) {
@@ -244,7 +243,8 @@ class Route {
         if (token.contains('Bearer')) {
           token = token.replaceAll('Bearer ', '');
 
-          var decClaimSet = verifyJwtHS256Signature(token, jwtKey);
+          var key = TokenUtil.getJwtKey();
+          var decClaimSet = verifyJwtHS256Signature(token, key);
           if (decClaimSet.expiry.isBefore(DateTime.now())) {
             return JwtException.tokenExpired.message;
           }


### PR DESCRIPTION
- Changed the massage when the jwt token fails
- You don't need more to pass a key when try to generate a token
- TokenUtil has more one method, getClaims(String token), pass the token and get all the claims.