### PR TITLE
fix to windows error.

### DIFF
--- a/lib/src/core/server_main.dart
+++ b/lib/src/core/server_main.dart
@@ -110,7 +110,11 @@ class GetServer with NodeMode {
     // ignore: unawaited_futures
     start(serverConfig);
 
-    await ProcessSignal.sigterm.watch().first;
+    if (Platform.isWindows)
+      await ProcessSignal.sigint.watch().first;
+    else
+      await ProcessSignal.sigterm.watch().first;
+
     return Future.value(this);
   }
 }


### PR DESCRIPTION
"Failed to listen for SIGTERM, osError: OS Error: The request is not supported" on Windows