### PR TITLE
fix NoSuchMethodError: Class 'Map<String, String>' has no instance method 'toJson'.

### DIFF
--- a/lib/src/core/src/widgets/custom.dart
+++ b/lib/src/core/src/widgets/custom.dart
@@ -166,7 +166,8 @@ class Json extends SenderWidget {
   Json(this.content);
   @override
   Widget build(BuildContext context) {
-    context.response!.sendJson(content.toJson());
+    final data = content is Map ? content : content.toJson();
+    context.response!.sendJson(data);
     return WidgetEmpty();
   }
 }


### PR DESCRIPTION
# Before
<img width="1384" alt="Snipaste_2021-06-05_17-16-40" src="https://user-images.githubusercontent.com/35302658/120887355-dd5e5000-c624-11eb-9a35-dd0c7bcae347.png">

# After
<img width="1329" alt="Snipaste_2021-06-05_17-23-59" src="https://user-images.githubusercontent.com/35302658/120887362-e64f2180-c624-11eb-907a-24fdd4f473d3.png">

# Dart Version
Dart SDK version: 2.14.0-136.0.dev (dev) (Thu May 20 23:58:47 2021 -0700) on "macos_x64"
Flutter:2.3.0-16.0.pre