### PR TITLE
Fix MultiPart upload file issue

### DIFF
--- a/lib/src/core/src/server_main.dart
+++ b/lib/src/core/src/server_main.dart
@@ -2,12 +2,12 @@ part of server;
 
 void runIsolate(void Function(dynamic _) isol) {
   isol(null);
-  // final list = List.generate(Platform.numberOfProcessors - 1, (index) => null);
-  
-  // Dart works well with 1 main thread and 2 threads. That's what brings the best 
-  // performance possible. Increasing the number of isolates, regardless of the 
+  final list = List.generate(Platform.numberOfProcessors - 1, (index) => null);
+
+  // Dart works well with 1 main thread and 2 threads. That's what brings the best
+  // performance possible. Increasing the number of isolates, regardless of the
   // number of cpus, will degrade performance.
-  for (int i = 0; i < 2; i++){
+  for (var item in list) {
     Isolate.spawn(isol, item);
   }
 }

--- a/lib/src/core/src/widgets/widget.dart
+++ b/lib/src/core/src/widgets/widget.dart
@@ -111,9 +111,8 @@ abstract class Element implements BuildContext {
 
   @override
   Future<MultipartUpload> file(String name, {Encoding encoder = utf8}) async {
-    final payload = await (request.payload(encoder: encoder)
-        as FutureOr<Map<dynamic, dynamic>>);
-    final multiPart = await payload[name];
+    final payload = await (request.payload(encoder: encoder));
+    final multiPart = await payload?[name];
     if (multiPart is MultipartUpload) {
       return multiPart;
     } else {


### PR DESCRIPTION
There are 3 things on this pull request:
- Fix issue #68 which casting failed from `Future<Map<dynamic, dynamic>?>` to `FutureOr<Map<dynamic, dynamic>>`
- Fix issue upload large file, the file stream stops before uploading complete. For example, I upload 80Mb file, but receive only 2MB on server. I fixed it by read bytes until end of stream.
- Revert commit 9537b1403614cdb76ef14481f964f27490b67e7a from @jonataslaw which cause build error because missing `item`, or @jonataslaw needs to do something to fix it, then I can merge into my branch.