### PR TITLE
The Socket page supports needAuth as true

### DIFF
--- a/lib/src/core/src/utils/token_util.dart
+++ b/lib/src/core/src/utils/token_util.dart
@@ -31,8 +31,12 @@ abstract class TokenUtil {
 
   static String getTokenFromHeader(ContextRequest request) {
     var token = request.header('Authorization')!.first as String;
-    token = token.replaceAll('Bearer ', '');
-
+    if (token.startsWith('Basic ')) {
+      token = token.replaceAll('Basic ', '');
+      token = utf8.decode(base64Decode(token));
+    } else {
+      token = token.replaceAll('Bearer ', '');
+    }
     return token;
   }
 

--- a/lib/src/routes/route.dart
+++ b/lib/src/routes/route.dart
@@ -104,8 +104,9 @@ class Route {
     try {
       if (token != null) {
         token = token.first;
-        if (token.contains('Bearer')) {
-          token = token.replaceAll('Bearer ', '');
+        if (token.contains('Bearer') ||
+            (req.requestMethod == Method.ws && token.contains('Basic'))) {
+          token = TokenUtil.getTokenFromHeader(req);
 
           var key = TokenUtil.getJwtKey()!;
           var decClaimSet = verifyJwtHS256Signature(token, key);


### PR DESCRIPTION
When GetServer sets WebSocket's GetPage to `needAuth: true`, JWT authentication will fail and a prompt of "Invalid JWT token!" will be thrown.

```
GetPage(
   name: Routes.SOCKET,
   page: () => SocketView(),
   binding: SocketBinding(),
   method: Method.ws,
   needAuth: true,
),
```

Because the Flutter client's GetSocket can only set the url parameter, [there is no place to set other headers](https://github.com/jonataslaw/getx/blob/f41fc874ab477206b9e56125e38a23e380463571/lib/get_connect/sockets/sockets.dart#L6). 

```
final socket = GetSocket(url);
```

[The websocket implementation](https://github.com/dart-lang/sdk/blob/6489835d8c62be6b7f27221fe2fbf4f7c5f93f48/sdk/lib/_http/websocket.dart#L312) of the dart language can support adding userInfo as authentication information in the url parameter, 

It's just that [the authentication information starts with Basic](https://github.com/dart-lang/sdk/blob/6489835d8c62be6b7f27221fe2fbf4f7c5f93f48/sdk/lib/_http/websocket_impl.dart#L1026) instead of JWT's Bearer.

Therefore, this modification changed GetServer to add checks for Basic authentication information. Although this Basic information is a JWT authentication Token, this is the minimum modification.

The modifications include:

1. /lib/src/routes/route.dart#L108, add condition to support tokens starting with Basic.
2. /lib/src/core/src/utils/token_util.dart#L34, add the code to obtain the Basic authentication token and decode it.